### PR TITLE
CI/CD 배포  트리거 조건 수정

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,10 +1,9 @@
 name: Deploy to GitHub Packages & AWS ECS
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types: [opened, synchronize, reopened]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
처음 CICD 설정할 때, deploy가 되는지 확인하느라 PR에 트리거 조건 걸었던 것을 유지시켜버렸음.
main 브랜치에 새 commit이 push 됐을 때 deploy 하는 조건으로 변경함.