### PR TITLE
JWT 토큰 이상 발생시 로그인 페이지로 리다이렉트

### DIFF
--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -30,8 +30,7 @@ axiosInstance.interceptors.response.use(
       // 토큰이 만료되었거나 유효하지 않은 경우
       localStorage.removeItem('token');
       localStorage.removeItem('user');
-      // 에러를 throw하여 각 컴포넌트에서 처리하도록 함
-      throw error;
+      window.location.href = '/login';
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
401 에러가 발생하면 로그아웃 처리 (토큰 초기화)를 하는데 페이지는 그대로 있어서 (따로 error 헨들링을 해줘야 함) `/login` 페이지로 강제로 리다이렉션하는 것으로 변경했습니다. 로그아웃 처리 됐다면 아무래도 로그인 페이지로 넘어가는 것이 좋을 것 같아요.