### PR TITLE
Set nginx authorization header

### DIFF
--- a/deployment/default.conf
+++ b/deployment/default.conf
@@ -19,6 +19,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
     }
 
     #error_page  404              /404.html;


### PR DESCRIPTION
Nginx에서 reverse proxy 할 때 authorization header를 같이 넘겨주지 않아서 배포된 사이트에서 인증 토큰 에러가 발생하고 있는 듯 함.