### PR TITLE
fix: ws error

### DIFF
--- a/src/chat/ChatRoom.js
+++ b/src/chat/ChatRoom.js
@@ -41,7 +41,7 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
   }, []);
 
   const connectWebSocket = useCallback(() => {
-    const socket = new SockJS("http://localhost:8080/wss");
+    const socket = new SockJS(config.apiUrl + "/wss");
     stompClient = Stomp.over(socket);
     stompClient.connect({}, onConnected, onError);
   }, [onConnected, onError]);


### PR DESCRIPTION
백엔드 url은 하드코딩하지 않고 변수로 받아와야 개발환경/운영환경 나뉘어서 각 환경에서 알아서 잘 작동하게 됩니다.

직접 적어놓으면 둘 중에 하나만 작동해요.