### PR TITLE
config: Nginx 클라이언트 최대 업로드 크기를 11MB로 늘리기

### DIFF
--- a/deployment/default.conf
+++ b/deployment/default.conf
@@ -19,6 +19,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 11M;
     }
 
     # 웹소켓 reverse proxy 설정


### PR DESCRIPTION
Nginx 기본값으로 인해 요청 크기제한이 1MB로 제한되어 1MB 이상의 파일을 업로드할 수 없었습니다.

이번 변경으로 10MB까지 파일 업로드가 가능합니다.