### PR TITLE
AWS 프리티어 EC2 배포로 변경

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,10 +67,12 @@ jobs:
         push: true
         tags: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:latest
 
-    - name: Deploy to AWS
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ap-northeast-2
-    - run: aws ecs update-service --cluster ${{ env.ECS_CLUSTER }} --service ${{ env.ECS_SERVICE }} --force-new-deployment
+    # AWS 배포 중단
+
+    # - name: Deploy to AWS
+    #   uses: aws-actions/configure-aws-credentials@v1
+    #   with:
+    #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #     aws-region: ap-northeast-2
+    # - run: aws ecs update-service --cluster ${{ env.ECS_CLUSTER }} --service ${{ env.ECS_SERVICE }} --force-new-deployment

--- a/deployment/default.conf
+++ b/deployment/default.conf
@@ -14,7 +14,7 @@ server {
 
     # API reverse proxy 설정
     location /api {
-        proxy_pass http://internal-carematching-backend-alb-1372095799.ap-northeast-2.elb.amazonaws.com;
+        proxy_pass http://host.docker.internal:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -24,7 +24,7 @@ server {
 
     # 웹소켓 reverse proxy 설정
     location /ws {
-        proxy_pass http://internal-carematching-backend-alb-1372095799.ap-northeast-2.elb.amazonaws.com;
+        proxy_pass http://host.docker.internal:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/admin/Cert.js
+++ b/src/admin/Cert.js
@@ -40,7 +40,7 @@ function Cert() {
 
     if (result.isConfirmed) {
       try {
-        const response = await axiosInstance.post(`/user/admin/cert/approve`, { username });
+        const response = await axiosInstance.post(`/user/admin/cert/${username}/pending/update`, { state: true });
         if (response.status === 200) {
           fetchCertUsers();
           Swal.fire({
@@ -71,7 +71,7 @@ function Cert() {
 
     if (result.isConfirmed) {
       try {
-        const response = await axiosInstance.post(`/user/admin/cert/revoke`, { username });
+        const response = await axiosInstance.post(`/user/admin/cert/pending/update`, { username, state: false });
         if (response.status === 200) {
           fetchCertUsers();
           Swal.fire({


### PR DESCRIPTION
기존에 사용하던 CloudFront - ALB - ECS (Fargate) 배포 구성을 사용하지 않고 단일 EC2 인스턴스로 이전

사유: 비용 문제 (기존 약 $100 → 새로운 환경은 거의 무료)