### PR TITLE
feat: 메시지 읽음 처리 추가 및 읽음 UI 표시

### DIFF
--- a/src/chat/ChatRoom.css
+++ b/src/chat/ChatRoom.css
@@ -61,11 +61,13 @@
   align-items: flex-start;
   gap: 8px;
   max-width: 80%;
+  position: relative;
 }
 
 .chat-message-mine {
   margin-left: auto;
   flex-direction: row-reverse;
+  margin-right: 8px;
 }
 
 .chat-message-avatar {
@@ -85,6 +87,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  position: relative; /* make this the positioning context for the read indicator */
 }
 
 .chat-message-username {
@@ -98,6 +101,23 @@
   padding: 8px 12px;
   border-radius: 16px;
   max-width: fit-content;
+}
+
+.chat-message-read-right {
+  /* remove absolute positioning and let flexbox place the indicator
+     For .chat-message-mine (row-reverse) this will appear to the left of the bubble */
+  position: static;
+  display: inline-flex;
+  align-self: center;
+  font-size: 0.75rem;
+  color: #888;
+  white-space: nowrap;
+  margin: 0 6px;
+}
+
+/* Ensure other-user messages (left) have the read indicator to their right outside the bubble */
+.chat-message-other {
+  margin-right: auto;
 }
 
 .chat-message-mine .chat-message-bubble {

--- a/src/chat/ChatRoom.js
+++ b/src/chat/ChatRoom.js
@@ -31,8 +31,6 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
     setRoomInfo(currentRoom || { name: `채팅방 #${roomId}` });
   }, [roomId, chatRooms]);
 
-
-
   const onConnected = useCallback(() => {
     console.log("✅ WebSocket 연결 성공");
     stompClient.subscribe(`/topic/chat/${roomId}`, onMessageReceived);
@@ -61,9 +59,11 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
     }
   }, []);
 
-  const fetchMessages = useCallback(async (roomId) => {
+  // roomId와 userId를 받아 메시지를 가져오도록 변경
+  const fetchMessages = useCallback(async (roomIdParam, userId) => {
     try {
-      const response = await axiosInstance.get(`/messages/${roomId}`);
+      const uid = userId || '';
+      const response = await axiosInstance.get(`/messages/${roomIdParam}/${uid}`);
       setMessages(response.data);
       console.log("✅ [INFO] 기존 메시지 불러오기:", response.data);
     } catch (error) {
@@ -112,13 +112,13 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
 
   useEffect(() => {
     if (roomId) {
-      fetchMessages(roomId);
+      fetchMessages(roomId, user?.username);
       connectWebSocket();
     }
     return () => {
       disconnectWebSocket();
     };
-  }, [roomId, fetchMessages, connectWebSocket, disconnectWebSocket]);
+  }, [roomId, fetchMessages, connectWebSocket, disconnectWebSocket, user?.username]);
 
   // 메시지들을 createdDate(월/일) 기준으로 그룹화
   const groupedMessages = messages.reduce((groups, message) => {
@@ -151,8 +151,7 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
             {groupedMessages[date].map((msg, index) => (
               <div
                 key={msg.createdAt + index}
-                className={`chat-message ${msg.username === user.username ? "chat-message-mine" : "chat-message-other"}`}
-              >
+                className={`chat-message ${msg.username === user?.username ? "chat-message-mine" : "chat-message-other"}`}>
                 <div className="chat-message-bubble">
                   <p className="chat-message-text">{msg.message}</p>
                   <span className="chat-message-time">{msg.createdTime}</span>

--- a/src/chat/ChatRoom.js
+++ b/src/chat/ChatRoom.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from "react";
+import React, { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import config from "../config/config";
 import axiosInstance from "../api/axiosInstance";
 import { useAuth } from "../context/AuthContext";
@@ -19,6 +19,25 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
   // 메시지 목록을 렌더링하는 컨테이너 참조
   const chatMessagesRef = useRef(null);
   const navigate = useNavigate();
+
+  // 특정 채팅방의 마지막 메시지 ID로 읽음 처리 호출
+  const markAsReadRef = useRef(null);
+  // track last epoch we sent to backend to avoid duplicate mark-as-read calls
+  const lastSentReadEpochRef = useRef(null);
+  // stable ref function to call backend without creating hook deps
+  useEffect(() => {
+    markAsReadRef.current = async (roomIdParam, userId, lastMessageId) => {
+      if (!roomIdParam || !userId || !lastMessageId) return;
+      try {
+        await axiosInstance.post(`/messages/${roomIdParam}/${userId}/read`, lastMessageId, {
+          headers: { 'Content-Type': 'text/plain' }
+        });
+        console.log(`✅ [INFO] 읽음 처리: room=${roomIdParam}, user=${userId}, last=${lastMessageId}`);
+      } catch (err) {
+        console.error("❌ [ERROR] 읽음 처리 실패:", err);
+      }
+    };
+  }, []);
 
   const onMessageReceived = useCallback((payload) => {
     const message = JSON.parse(payload.body);
@@ -66,6 +85,23 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
       const response = await axiosInstance.get(`/messages/${roomIdParam}/${uid}`);
       setMessages(response.data);
       console.log("✅ [INFO] 기존 메시지 불러오기:", response.data);
+  // 읽음 처리: 상대방의 마지막 메시지(내 메시지 제외)를 찾아 시간(createdAt 등)을 epoch(ms)로 변환해 전송
+  // We notify backend which of the other user's messages we've read (so backend can update read status for them)
+  const last = response.data && response.data.length ? response.data.slice().reverse().find(m => m?.username !== uid) : null;
+      const candidate = last?.createdAt || last?.timestamp || (last?.createdDate && last?.createdTime ? `${last.createdDate} ${last.createdTime}` : null);
+      let epoch = null;
+      if (candidate) {
+        const num = Number(candidate);
+        if (!isNaN(num)) {
+          epoch = num;
+        } else {
+          const parsed = Date.parse(candidate);
+          if (!isNaN(parsed)) epoch = parsed;
+        }
+      }
+        if (epoch && markAsReadRef.current) {
+          markAsReadRef.current(roomIdParam, uid, String(epoch));
+        }
     } catch (error) {
       console.error("❌ [ERROR] 메시지 불러오기 오류:", error);
       Swal.fire({
@@ -101,7 +137,7 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
       // scrollTop을 scrollHeight로 설정해서 맨 아래로 스크롤
       chatMessagesRef.current.scrollTop = chatMessagesRef.current.scrollHeight;
     }
-  }, [messages]);
+  }, [messages, user?.username]);
 
   const handleDecide = async () => {
     const transactionId = await axiosInstance.post(`/transactions/add`, {
@@ -120,6 +156,31 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
     };
   }, [roomId, fetchMessages, connectWebSocket, disconnectWebSocket, user?.username]);
 
+  // 새로운 메시지가 추가될 때(실시간 수신) 읽음 처리
+  useEffect(() => {
+    if (!messages || messages.length === 0) return;
+  // 실시간 수신 시에도 내 메시지는 제외하고 상대방의 마지막 메시지에 대해서만 읽음 처리
+  const last = messages && messages.length ? messages.slice().reverse().find(m => m?.username !== user?.username) : null;
+  const candidate = last?.createdAt || last?.timestamp || (last?.createdDate && last?.createdTime ? `${last.createdDate} ${last.createdTime}` : null);
+    let epoch = null;
+    if (candidate) {
+      const num = Number(candidate);
+      if (!isNaN(num)) {
+        epoch = num;
+      } else {
+        const parsed = Date.parse(candidate);
+        if (!isNaN(parsed)) epoch = parsed;
+      }
+    }
+    if (epoch && markAsReadRef.current) {
+      // avoid sending same epoch repeatedly
+      if (String(lastSentReadEpochRef.current) !== String(epoch)) {
+        lastSentReadEpochRef.current = String(epoch);
+        markAsReadRef.current(roomId, user?.username, String(epoch));
+      }
+    }
+  }, [messages, roomId, user?.username]);
+
   // 메시지들을 createdDate(월/일) 기준으로 그룹화
   const groupedMessages = messages.reduce((groups, message) => {
     const date = message.createdDate;
@@ -129,6 +190,23 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
     groups[date].push(message);
     return groups;
   }, {});
+
+  // read가 true인 메시지 중 가장 최신(createdAt 기준)인 메시지의 epoch(ms)
+  const lastReadEpoch = useMemo(() => {
+    // We want the latest epoch of *my* messages that the other user has read.
+    const epochs = messages
+      .filter((m) => m?.read && m?.username === user?.username)
+      .map((m) => {
+        const candidate = m?.createdAt || m?.timestamp || (m?.createdDate && m?.createdTime ? `${m.createdDate} ${m.createdTime}` : null);
+        if (!candidate) return null;
+        const num = Number(candidate);
+        if (!isNaN(num)) return num;
+        const parsed = Date.parse(candidate);
+        return isNaN(parsed) ? null : parsed;
+      })
+      .filter(Boolean);
+    return epochs.length ? Math.max(...epochs) : null;
+  }, [messages, user?.username]);
 
   // 그룹화된 날짜들을 정렬
   const sortedDates = Object.keys(groupedMessages).sort();
@@ -148,16 +226,30 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
         {sortedDates.map((date) => (
           <div key={date} className="chat-date-group">
             <div className="chat-date-header">{date}</div>
-            {groupedMessages[date].map((msg, index) => (
-              <div
-                key={msg.createdAt + index}
-                className={`chat-message ${msg.username === user?.username ? "chat-message-mine" : "chat-message-other"}`}>
-                <div className="chat-message-bubble">
-                  <p className="chat-message-text">{msg.message}</p>
-                  <span className="chat-message-time">{msg.createdTime}</span>
+            {groupedMessages[date].map((msg, index) => {
+              const msgEpoch = (() => {
+                const c = msg?.createdAt || msg?.timestamp || (msg?.createdDate && msg?.createdTime ? `${msg.createdDate} ${msg.createdTime}` : null);
+                if (!c) return null;
+                const n = Number(c);
+                if (!isNaN(n)) return n;
+                const p = Date.parse(c);
+                return isNaN(p) ? null : p;
+              })();
+              const isLastRead = lastReadEpoch && msgEpoch && Number(lastReadEpoch) === Number(msgEpoch);
+              return (
+                <div
+                  key={msg.createdAt + index}
+                  className={`chat-message ${msg.username === user?.username ? "chat-message-mine" : "chat-message-other"}`}>
+                  <div className="chat-message-bubble">
+                    <p className="chat-message-text">{msg.message}</p>
+                    <span className="chat-message-time">{msg.createdTime}</span>
+                  </div>
+                  {msg.username === user?.username && isLastRead && (
+                    <div className="chat-message-read-right">읽음</div>
+                  )}
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         ))}
       </div>

--- a/src/chat/ChatRoom.js
+++ b/src/chat/ChatRoom.js
@@ -82,7 +82,7 @@ const ChatRoom = ({ roomId, onBack, onClose, chatRooms }) => {
   const fetchMessages = useCallback(async (roomIdParam, userId) => {
     try {
       const uid = userId || '';
-      const response = await axiosInstance.get(`/messages/${roomIdParam}/${uid}`);
+      const response = await axiosInstance.get(`/messages/${roomIdParam}`);
       setMessages(response.data);
       console.log("✅ [INFO] 기존 메시지 불러오기:", response.data);
   // 읽음 처리: 상대방의 마지막 메시지(내 메시지 제외)를 찾아 시간(createdAt 등)을 epoch(ms)로 변환해 전송


### PR DESCRIPTION
### 요약
- 메시지 로드(초기 로드 및 실시간 수신) 시 상대방 메시지의 마지막 시점을 백엔드에 읽음(read)으로 전송
- 내 메시지 중 상대가 읽은 마지막 메시지에 대해 UI에 "읽음" 표시 추가
- 
### 핵심 변경사항
- ChatRoom.js
  - fetchMessages(roomIdParam, userId)로 변경. GET /messages/{roomId} 호출.
  - markAsReadRef, lastSentReadEpochRef 추가하여 읽음 호출을 안정적으로 관리.
  - 메시지 초기 로드 시 상대방 마지막 메시지 시각을 epoch으로 파싱해 POST /messages/{roomId}/{userId}/read (plain text body) 호출.
### API 요구사항 (백엔드와 호환성을 맞춰야 함)
- POST /messages/{roomId}/{userId}/read : 요청 바디에 ISO 날짜/시간 문자열(plain text), Content-Type: text/plain

### 변경된 파일
- ChatRoom.js (주요 로직 추가/수정)
- ChatRoom.css (스타일/읽음 표시 추가)
