### PR TITLE
feat: HTTPS 설정 구성

### DIFF
--- a/deployment/default.conf
+++ b/deployment/default.conf
@@ -1,65 +1,71 @@
 server {
-    listen       80;
-    listen  [::]:80;
-    server_name  localhost;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
+  ssl_certificate /etc/letsencrypt/live/carematching.kro.kr/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/carematching.kro.kr/privkey.pem;
 
-    #access_log  /var/log/nginx/host.access.log  main;
+  # ACME 인증을 위한 경로
+  location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+  }
 
-    # react-router-dom의 라우팅을 위한 try_files 설정
-    location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        try_files $uri $uri/ /index.html;
-    }
+  # HSTS (ngx_http_headers_module is required) (63072000 seconds)
+  add_header Strict-Transport-Security "max-age=63072000" always;
 
-    # API reverse proxy 설정
-    location /api {
-        proxy_pass http://host.docker.internal:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        client_max_body_size 11M;
-    }
+  # react-router-dom의 라우팅을 위한 try_files 설정
+  location / {
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+      try_files $uri $uri/ /index.html;
+  }
 
-    # 웹소켓 reverse proxy 설정
-    location /ws {
-        proxy_pass http://host.docker.internal:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+  # API reverse proxy 설정
+  location /api {
+      proxy_pass http://host.docker.internal:8080;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      client_max_body_size 11M;
+  }
 
-    #error_page  404              /404.html;
+  # 웹소켓 reverse proxy 설정
+  location /ws {
+      proxy_pass http://host.docker.internal:8080;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+  }
 
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
+  #error_page  404              /404.html;
 
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
+  # redirect server error pages to the static page /50x.html
+  #
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+      root   /usr/share/nginx/html;
+  }
+}
 
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
+# intermediate configuration
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ecdh_curve X25519:prime256v1:secp384r1;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+ssl_prefer_server_ciphers off;
 
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
+# see also ssl_session_ticket_key alternative to stateful session cache
+ssl_session_timeout 1d;
+ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+
+# curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam
+ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # use let's encrypt dhparam
+
+# HSTS
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+
+  return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
[모질라의 SSL 설정](https://ssl-config.mozilla.org/#server=nginx&version=1.29.1&config=intermediate&openssl=3.4.0&ocsp=false&guideline=5.7) 기반으로 Nginx TLS 설정 구성

### 시스템에 개별 설정 진행한 부분
- Certbot을 통해 Let's Encrypt 인증서 발행
  - `/etc/letsencrypt` 디렉토리에 인증서가 있어야 함
  - 도메인 정보 `carematching.kro.kr`에 맞춰 설정한 상태
- Nginx 버전 1.29.1

디테일한 과정은 HTTPS 설정 진행기 참고: https://alex00728.tistory.com/77

### 주의 사항

TLS 인증서가 준비되지 않은 상태에서 이 변경 사항을 적용할 경우 웹페이지 접근이 불가능합니다. 
(인증서 파일이 존재하지 않는다는 오류를 반환함)